### PR TITLE
demo: add option to change keyboard layout

### DIFF
--- a/src/demo/App.js
+++ b/src/demo/App.js
@@ -8,7 +8,14 @@ class App extends Component {
 	  super();
 	  this.state = {
 	    input: "tremolo",
+	    keyboardLayout: "azerty",
 	  };
+	}
+
+	toggleLayout() {
+	  return this.state.keyboardLayout === "azerty"
+	    ? "qwerty"
+	    : "azerty";
 	}
 
 	render() {
@@ -25,6 +32,10 @@ class App extends Component {
 	      <Distortion input={"monosynth"} output={"distortion"} />
 	      <Tremolo input={"monosynth"} output={"tremolo"} />
 	      <AudioOutput input={this.state.input} />
+
+              <button onClick={() => this.setState({ keyboardLayout: this.toggleLayout() })}>
+                {"keyboard layout: " + this.state.keyboardLayout}
+              </button>
 	    </Connector>
 	  );
 	}

--- a/src/lib/components/ComputerKeyboard/ComputerKeyboard.js
+++ b/src/lib/components/ComputerKeyboard/ComputerKeyboard.js
@@ -180,6 +180,8 @@ export class ComputerKeyboard extends Component {
 	    // TODO - this should set midiMsg to a TRUE midi messages, or at least the sort of message that's received and sent through by the midi controller
 	    const pitch = this.keySynth[e.keyCode];
 
+	    if (!pitch) return;
+
 	    this.setState({
 	      midiMsg: {
 	        type: midiMessages.NOTE_ON,
@@ -225,6 +227,8 @@ export class ComputerKeyboard extends Component {
 
 	  // set noteoff midi message to state.
 	  const pitch = this.keySynth[e.keyCode];
+	  
+	  if (!pitch) return;
 
 	  this.setState({
 	    midiMsg: {


### PR DESCRIPTION
this commit adds a button to the demo app that let's you switch between keyboard layouts.

note: some keys aren't mapped in qwerty which makes the app explode when trying to set the pitch to undefined. this commit adds a return statement right before setting the state. this might not be the best solution, but it prevents the app from breaking when using qwerty! (keycode was '90', or qwerty 'z')
